### PR TITLE
Develop

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -37,6 +37,9 @@ http://aecci-ucr.com {
     handle_path /cursos/* {
         root * /var/www/cursos
 
+        # Prevent browsers from caching directory listings
+        header Cache-Control "no-cache"
+
         # Enable the directory browser and hide hidden/git files
         file_server {
             browse /var/www/frontend/browse.html

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -1,5 +1,5 @@
-# Replace :80 with your domain (e.g., cursoteca.ucr.ac.cr) for automatic HTTPS
-:aecci-ucr.com {
+# http:// prefix — Cloudflare handles TLS, origin serves plain HTTP
+http://aecci-ucr.com {
     # Enable compression for faster loading
     encode gzip
 
@@ -38,7 +38,8 @@
         root * /var/www/cursos
 
         # Enable the directory browser and hide hidden/git files
-        file_server browse /var/www/frontend/browse.html {
+        file_server {
+            browse /var/www/frontend/browse.html
             hide .* .gitkeep .gitignore .gitattributes .gitmodules
         }
     }
@@ -67,6 +68,6 @@
 }
 
 # Admin subdomain for managing content through FileBrowser
-admin.aecci-ucr.com {
+http://admin.aecci-ucr.com {
     reverse_proxy filebrowser:80
 }

--- a/frontend/browse.html
+++ b/frontend/browse.html
@@ -784,7 +784,7 @@ footer {
 	margin-bottom: 6px;
 }
 .back-home a {
-	font-size: 12px;
+	font-size: 15px;
 	color: #0066cc;
 	text-decoration: none;
 	letter-spacing: 0.3px;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -815,7 +815,6 @@
         </svg>
       </span>
       <ul class="nav-links">
-        <li class="nav-text-link"><a href="#sobre">Sobre Nosotros</a></li>
         <li class="nav-text-link"><a href="#proyectos">Proyectos</a></li>
         <li class="nav-text-link"><a href="#contacto">Contacto</a></li>
         <li>
@@ -1114,7 +1113,7 @@
           <dl class="contact-list">
             <div>
               <dt>Correo general</dt>
-              <dd><a href="mailto:aecci@universidad.ac.cr">aecci@universidad.ac.cr</a></dd>
+              <dd><a href="mailto:aecci.ucr@ucr.ac.cr">aecci.ucr@ucr.ac.cr</a></dd>
             </div>
             <div>
               <dt>Sobre Cursoteca</dt>
@@ -1156,7 +1155,6 @@
           <p class="footer-tagline">Asociación de Estudiantes de Computación e Informática</p>
         </div>
         <ul class="footer-nav">
-          <li><a href="#sobre">Sobre Nosotros</a></li>
           <li><a href="#proyectos">Proyectos</a></li>
           <li><a href="/cursos/">Cursoteca</a></li>
           <li><a href="#contacto">Contacto</a></li>
@@ -1164,7 +1162,7 @@
       </div>
       <div class="footer-bottom">
         Asociación de Estudiantes de Computación e Informática de la UCR · 
-        <a href="mailto:aecci@universidad.ac.cr">Contacto</a>
+        <a href="mailto:aecci.ucr@ucr.ac.cr">Contacto</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
**Caddy server configuration updates:**

* Changed `Caddyfile` to use `http://` for both `aecci-ucr.com` and `admin.aecci-ucr.com`, as Cloudflare will handle TLS termination. [[1]](diffhunk://#diff-160fa236290f8a8175fea9e881eb249c31febc076f5bdf19875a241f860ac3e3L1-R2) [[2]](diffhunk://#diff-160fa236290f8a8175fea9e881eb249c31febc076f5bdf19875a241f860ac3e3L70-R74)
* Added a `Cache-Control: no-cache` header to the `/cursos/*` path to prevent browsers from caching directory listings.
* Updated the `file_server` directive to a more current syntax for directory browsing and hiding hidden/git files.

**Frontend content and style updates:**

* Updated the main contact email address throughout `index.html` from `aecci@universidad.ac.cr` to `aecci.ucr@ucr.ac.cr`. [[1]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L1117-R1116) [[2]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L1159-R1165)
* Removed "Sobre Nosotros" navigation links from both the main navigation and footer in `index.html`. [[1]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L818) [[2]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72L1159-R1165)
* Increased the font size for the "back home" link in `browse.html` for improved visibility.